### PR TITLE
[a11y] Adds lang attribute to calendar

### DIFF
--- a/templates/schedule.jinja2.html
+++ b/templates/schedule.jinja2.html
@@ -39,7 +39,7 @@
                   {% for i in range(rowspan - 1) %}
                     {{ rowspans.append(room.id) or '' }}
                   {% endfor %}
-                  <td rowspan="{{ rowspan }}" class="{{ talk.submission_type.en | slug }}">
+                  <td rowspan="{{ rowspan }}" class="{{ talk.submission_type.en | slug }}" {% if talk.content_locale %}lang="{{ talk.content_locale }}"{% endif %}>
                     <a href="{{ url_for('talks', category=talk.submission_type.en | slug, lang=lang, _anchor='talk-' + talk.code) }}" target="_parent">
                       {{ talk.title }}
                     </a>

--- a/templates/schedule.jinja2.html
+++ b/templates/schedule.jinja2.html
@@ -39,7 +39,7 @@
                   {% for i in range(rowspan - 1) %}
                     {{ rowspans.append(room.id) or '' }}
                   {% endfor %}
-                  <td rowspan="{{ rowspan }}" class="{{ talk.submission_type.en | slug }}" {% if talk.content_locale %}lang="{{ talk.content_locale }}"{% endif %}>
+                  <td rowspan="{{ rowspan }}" class="{{ talk.submission_type.en | slug }}" {% if talk.content_locale %}lang="{{ talk.content_locale | lower }}"{% endif %}>
                     <a href="{{ url_for('talks', category=talk.submission_type.en | slug, lang=lang, _anchor='talk-' + talk.code) }}" target="_parent">
                       {{ talk.title }}
                     </a>


### PR DESCRIPTION
L'attribut `lang` permet aux lecteurs d'écran et aux robots de savoir dans quelle langue le contenu est écrit afin de pouvoir le reproduire/lire correctement. C’est rare que la langue du contenu soit disponible, autant s’en servir !

Je n'ai pas pu tester faute de jeton ou autre, mais il n’y a pas de raison que ça ne marche pas, à en lire le reste du code. Retours bienvenus.